### PR TITLE
Added possibility to specify elastic search settings from Bungiesearch's

### DIFF
--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -178,8 +178,16 @@ class Bungiesearch(Search):
             timeout = getattr(Bungiesearch.BUNGIE, 'TIMEOUT', Bungiesearch.DEFAULT_TIMEOUT)
 
         search_keys = ['using', 'index', 'doc_type', 'extra']
-        search_settings = dict((k, v) for k, v in kwargs.iteritems() if k in search_keys)
-        es_settings = dict((k, v) for k, v in kwargs.iteritems() if k not in search_keys)
+        search_settings, es_settings = {}, {}
+        for k, v in kwargs.iteritems():
+            if k in search_keys:
+                search_settings[k] = v
+            else:
+                es_settings[k] = v
+
+        if not es_settings:
+            # If there aren't any provided elasticsearch settings, let's see if it's defined in the settings.
+            es_settings = Bungiesearch.BUNGIE.get('ES_SETTINGS', {})
 
         # Building a caching key to cache the es_instance for later use (and retrieved a previously cached es_instance).
         cache_key = Bungiesearch._build_key(urls, timeout, **es_settings)

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from time import sleep
 
 from bungiesearch.management.commands import search_index
-from bungiesearch.utils import update_index, __str_to_tzdate__
+from bungiesearch.utils import update_index
 from django.test import TestCase
 import pytz
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,7 @@
-import sys
 import os
+import sys
+
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # Make sure the copy of seeker in the directory above this one is used.
 sys.path.insert(0, BASE_DIR)


### PR DESCRIPTION
settings. Tested locally. Did not find a good way to automatically test
that (because the settings are efficiently read only once). You can test
by setting `'use_ssl'` to `True` and if your ES instance doesn't allow
it, it should raise a ConnectionError. Fixes #45 .
