### PR TITLE
Search aliases have access to doc type / model

### DIFF
--- a/bungiesearch/aliases.py
+++ b/bungiesearch/aliases.py
@@ -35,3 +35,10 @@ class SearchAlias(object):
 
     def alias_for(self, **kwargs):
         raise NotImplementedError('{} does not provide an implementation for alias_for.'.format(self._classname))
+    
+    def get_model(self):
+        if self.model:
+            return self.model
+        if self.search_instance._doc_type and len(self.search_instance._doc_type) == 1:
+            return self.search_instance._model_name_to_model_idx[self.search_instance._doc_type[0]].get_model()
+        raise ValueError('Instance associated to zero doc types or more than one.')

--- a/tests/core/search_aliases.py
+++ b/tests/core/search_aliases.py
@@ -29,3 +29,10 @@ class NonApplicableAlias(SearchAlias):
 
     class Meta:
         models = (NoUpdatedField,)
+
+class ReturningSelfAlias(SearchAlias):
+    def alias_for(self):
+        return self
+
+    class Meta:
+        alias_name = 'get_alias_for_test'

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -151,6 +151,11 @@ class ModelIndexTestCase(TestCase):
         alias_dictd = Article.objects.search.bsearch_title('title query').bsearch_titlefilter('title filter').to_dict()
         expected = {'query': {'filtered': {'filter': {'term': {'title': 'title filter'}}, 'query': {'match': {'title': 'title query'}}}}}
         self.assertEqual(alias_dictd, expected, 'Alias on Bungiesearch instance did not return the expected dictionary.')
+    
+    def test_search_alias_model(self):
+        self.assertEqual(Article.objects.bsearch_get_alias_for_test().get_model(), Article, 'Unexpected get_model information on search alias.')
+        self.assertEqual(Article.objects.search.bsearch_title('title query').bsearch_get_alias_for_test().get_model(), Article, 'Unexpected get_model information on search alias.')
+        self.assertRaises(ValueError, Bungiesearch().bsearch_get_alias_for_test().get_model)
 
     def test_post_save(self):
         art = {'title': 'Title three',


### PR DESCRIPTION
All search aliases now have access to the `model` they will be searching on via `self.get_model()`. Implements #59 .
