### PR TITLE
Adds search meta information in each result (stored in `_searchmeta`).

### DIFF
--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -166,7 +166,7 @@ class Bungiesearch(Search):
                 results[pos] = result
             else:
                 model_results[model_name].append(result.id)
-                found_results['{}.{}'.format(model_name, result.id)] = pos
+                found_results['{}.{}'.format(model_name, result.id)] = (pos, result._meta)
         # Now that we have model ids per model name, let's fetch everything at once.
 
         for model_name, ids in model_results.iteritems():
@@ -183,9 +183,11 @@ class Bungiesearch(Search):
 
                 if desired_fields: # Prevents setting the database fetch to __fields but not having specified any field to elasticsearch.
                     items = items.only(*[field for field in model_obj._meta.get_all_field_names() if field in desired_fields])
-            # Let's reposition each item in the results.
+            # Let's reposition each item in the results and set the _bungiesearch meta information.
             for item in items:
-                results[found_results['{}.{}'.format(model_name, item.pk)]] = item
+                pos, meta = found_results['{}.{}'.format(model_name, item.pk)]
+                item._searchmeta = meta
+                results[pos] = item
 
         return results
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from os.path import join, dirname
 from setuptools import setup, find_packages
 
-VERSION = (0, 0, 10)
+VERSION = (0, 0, 11)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -240,3 +240,10 @@ class ModelIndexTestCase(TestCase):
         lazy = Article.objects.bsearch_title_search('title').only('pk').fields('_id')
         print len(lazy) # Returns the total hits computed by elasticsearch.
         assert all([type(item) == Article for item in lazy.filter('range', effective_date={'lte': '2014-09-22'})[5:7]])
+    
+    def test_meta(self):
+        '''
+        Test search meta is set.
+        '''
+        lazy = Article.objects.bsearch_title_search('title').only('pk').fields('_id')
+        assert all([hasattr(item._searchmeta) for item in lazy.filter('range', effective_date={'lte': '2014-09-22'})[5:7]])

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ bungiesearch
 cov-core==1.14.0
 coverage==3.7.1
 elasticsearch==1.2.0
--e git+https://github.com/elasticsearch/elasticsearch-dsl-py@b0a6ba1a4e512014da53edf16ee577218d876f18#egg=elasticsearch_dsl-master
+-e git+https://github.com/elasticsearch/elasticsearch-dsl-py@9cf802968d857e9788a6ee2746423453bf16082f#egg=elasticsearch_dsl-master
 pytz==2014.7
 six==1.8.0
 urllib3==1.9


### PR DESCRIPTION
Also upped elasticsearch-dsl-py requirements.

Now in version 0.0.11.
