### PR TITLE
sort model_items queryset by PK when indexing

### DIFF
--- a/bungiesearch/utils.py
+++ b/bungiesearch/utils.py
@@ -44,6 +44,9 @@ def update_index(model_items, model_name, action='index', bulk_size=100, num_doc
             else:
                 model_items = filter_model_items(index_instance, model_items, model_name, start_date, end_date)
                 num_docs = model_items.count()
+
+                if not model_items.ordered:
+                    model_items = model_items.order_by('pk')
         else:
             logging.warning('Limiting the number of model_items to {} to {}.'.format(action, num_docs))
 


### PR DESCRIPTION
While indexing objects, mutltiple queries are made with offsets and
limits. Without an explicit order, multiple queries can potentially
return the same rows. This is likely to happen if there are other
database writes happening during indexing.

Ordering unordered querysets by primary key will help avoid models
missing from the index

If you have any idea how to test this, I'm all ears.