### PR TITLE
ignore index already exists error on index creation

### DIFF
--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -135,7 +135,7 @@ class Command(BaseCommand):
                 analysis = mdl_idx.collect_analysis()
 
                 logging.info('Creating index {} with {} doctypes.'.format(index, len(mapping)))
-                es.indices.create(index=index, body={'mappings': mapping, 'settings': {'analysis': analysis}})
+                es.indices.create(index=index, body={'mappings': mapping, 'settings': {'analysis': analysis}}, ignore=400)
 
             es.cluster.health(index=','.join(indices), wait_for_status='green', timeout=30)
 


### PR DESCRIPTION
if anyone is running the index creation command, generally, it's more convenient to ignore the IndexAlreadyExistsException on index creation
![image](https://cloud.githubusercontent.com/assets/380950/11648071/c74f4474-9d24-11e5-9178-6f237f16020e.png)
sample taken from http://elasticsearch-py.readthedocs.org/en/master/api.html