### PR TITLE
Wait 30 seconds to time out after creating an index

### DIFF
--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -143,7 +143,7 @@ class Command(BaseCommand):
                 logging.info('Creating index {} with {} doctypes.'.format(index, len(mapping)))
                 es.indices.create(index=index, body={'mappings': mapping, 'settings': {'analysis': analysis}})
 
-            es.cluster.health(index=','.join(indices), wait_for_status='green', timeout=30)
+            es.cluster.health(index=','.join(indices), wait_for_status='green', request_timeout=30)
 
         elif options['action'] == 'update-mapping':
             if options['index']:


### PR DESCRIPTION
"timeout" is a query parameter sent to the cluster health endpoint, and
30 is already the default. "request_timeout" configures how long python
will wait for that query.