### PR TITLE
Fix using timeout specified in settings

### DIFF
--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -220,7 +220,7 @@ class Bungiesearch(Search):
 
         urls = urls or Bungiesearch.BUNGIE['URLS']
         if not timeout:
-            timeout = getattr(Bungiesearch.BUNGIE, 'TIMEOUT', Bungiesearch.DEFAULT_TIMEOUT)
+            timeout = Bungiesearch.BUNGIE.get('TIMEOUT', Bungiesearch.DEFAULT_TIMEOUT)
 
         search_keys = ['using', 'index', 'doc_type', 'extra']
         search_settings, es_settings = {}, {}

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -1,0 +1,13 @@
+from bungiesearch import Bungiesearch
+from django.conf import settings
+from django.test import TestCase
+
+
+class SettingsTestCase(TestCase):
+
+    def test_timeout_used(self):
+        settings.BUNGIESEARCH['TIMEOUT'] = 29
+        search = Bungiesearch()
+
+        self.assertEqual(search.BUNGIE['TIMEOUT'], 29)
+        self.assertEqual(search._using.transport.kwargs['timeout'], 29)


### PR DESCRIPTION
The TIMEOUT was being ignored because getattr doesn't work on dictionaries for it's keys. It should use the dict.get to get the settings. I also added the first settings test, yay.