### PR TITLE
management commands may run long-lived commands, make sense to allow override of timeout

### DIFF
--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -78,13 +78,19 @@ class Command(BaseCommand):
             default=None,
             type='str',
             help='Specify the end date and time of documents to be indexed.'),
+        make_option('--timeout',
+            action='store',
+            dest='timeout',
+            default=None,
+            type='int',
+            help='Specify the timeout in seconds for each operation.')
         )
 
     def handle(self, *args, **options):
         del args
         logging.basicConfig(level='INFO')
 
-        src = Bungiesearch()
+        src = Bungiesearch(timeout=options.get('timeout'))
         es = src.get_es_instance()
 
         if not options['action']:


### PR DESCRIPTION
since management commands may do expensive things like deleting indices or creating indices
it would be convenient to optionally pass in a `--timeout` value to override the default `timeout`

in our django application setup, the default `timeout` value is optimized for query + indexing items, not for index creation or deletion