### PR TITLE
allow clear index to have timeout override too

### DIFF
--- a/bungiesearch/management/commands/clear_index.py
+++ b/bungiesearch/management/commands/clear_index.py
@@ -20,6 +20,12 @@ class Command(BaseCommand):
             dest='confirmed',
             default=False,
             help='Flag needed to confirm the clear index.'),
+        make_option('--timeout',
+            action='store',
+            dest='timeout',
+            default=None,
+            type='int',
+            help='Specify the timeout in seconds for each operation.')
        )
 
     def handle(self, **options):


### PR DESCRIPTION
clear index command can have the `timeout` override too, rebuild index command will inherit this option too because it uses the same options as clear index