### PR TITLE
make signal processor thread safe

### DIFF
--- a/bungiesearch/signals.py
+++ b/bungiesearch/signals.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from importlib import import_module
+from threading import Lock
 
 from django.db.models import signals
 
@@ -17,32 +18,39 @@ def get_signal_processor():
         signal_class = BungieSignalProcessor
     return signal_class()
 
-__items_to_be_indexed__ = defaultdict(list)
+
 class BungieSignalProcessor(object):
+
+    __index_lock = Lock()
+    __items_to_be_indexed = defaultdict(list)
 
     def post_save_connector(self, sender, instance, **kwargs):
         try:
             Bungiesearch.get_index(sender, via_class=True)
         except KeyError:
-            return # This model is not managed by Bungiesearch.
+            return  # This model is not managed by Bungiesearch.
 
         try:
             buffer_size = Bungiesearch.BUNGIE['SIGNALS']['BUFFER_SIZE']
         except KeyError:
             buffer_size = 100
 
-        __items_to_be_indexed__[sender].append(instance)
+        items = None
+        with self.__index_lock:
+            self.__items_to_be_indexed[sender].append(instance)
+            if len(self.__items_to_be_indexed[sender]) >= buffer_size:
+                items = self.__items_to_be_indexed[sender]
+                # Let's now empty this buffer.
+                self.__items_to_be_indexed[sender] = []
 
-        if len(__items_to_be_indexed__[sender]) >= buffer_size:
-            update_index(__items_to_be_indexed__[sender], sender.__name__, bulk_size=buffer_size)
-            # Let's now empty this buffer or we'll end up reindexing every item which was previously buffered.
-            __items_to_be_indexed__[sender] = []
+        if items:
+            update_index(items, sender.__name__, bulk_size=buffer_size)
 
     def pre_delete_connector(self, sender, instance, **kwargs):
         try:
             Bungiesearch.get_index(sender, via_class=True)
         except KeyError:
-            return # This model is not managed by Bungiesearch.
+            return  # This model is not managed by Bungiesearch.
 
         delete_index_item(instance, sender.__name__)
 


### PR DESCRIPTION
the signal processor right now is not thread safe and may loose stuff if we're using multiple threads to enqueue instances for indexing

use a thread lock whenever modifying `items to be indexed`