### PR TITLE
signal timer to flush the items buffer

### DIFF
--- a/bungiesearch/signals.py
+++ b/bungiesearch/signals.py
@@ -1,8 +1,9 @@
 from collections import defaultdict
 from importlib import import_module
-from threading import Lock
+from threading import Lock, Timer
 
 from django.db.models import signals
+from django.utils.functional import cached_property
 
 from . import Bungiesearch
 from .utils import delete_index_item, update_index
@@ -23,6 +24,7 @@ class BungieSignalProcessor(object):
 
     __index_lock = Lock()
     __items_to_be_indexed = defaultdict(list)
+    __timers = {}
 
     def post_save_connector(self, sender, instance, **kwargs):
         try:
@@ -30,21 +32,20 @@ class BungieSignalProcessor(object):
         except KeyError:
             return  # This model is not managed by Bungiesearch.
 
-        try:
-            buffer_size = Bungiesearch.BUNGIE['SIGNALS']['BUFFER_SIZE']
-        except KeyError:
-            buffer_size = 100
-
         items = None
         with self.__index_lock:
             self.__items_to_be_indexed[sender].append(instance)
-            if len(self.__items_to_be_indexed[sender]) >= buffer_size:
+            if len(self.__items_to_be_indexed[sender]) >= self.buffer_size:
                 items = self.__items_to_be_indexed[sender]
                 # Let's now empty this buffer.
                 self.__items_to_be_indexed[sender] = []
+            elif sender not in self.__timers:
+                timer = Timer(5, self.flush_buffer, args=[sender])
+                timer.start()
+                self.__timers[sender] = timer
 
         if items:
-            update_index(items, sender.__name__, bulk_size=buffer_size)
+            update_index(items, sender.__name__, bulk_size=self.buffer_size)
 
     def pre_delete_connector(self, sender, instance, **kwargs):
         try:
@@ -54,6 +55,15 @@ class BungieSignalProcessor(object):
 
         delete_index_item(instance, sender.__name__)
 
+    def flush_buffer(self, sender):
+        with self.__index_lock:
+            items = self.__items_to_be_indexed[sender]
+            self.__items_to_be_indexed[sender] = []
+            self.__timers.pop(sender, None)
+
+        if items:
+            update_index(items, sender.__name__, bulk_size=self.buffer_size)
+
     def setup(self, model):
         signals.post_save.connect(self.post_save_connector, sender=model)
         signals.pre_delete.connect(self.pre_delete_connector, sender=model)
@@ -61,3 +71,10 @@ class BungieSignalProcessor(object):
     def teardown(self, model):
         signals.pre_delete.disconnect(self.pre_delete_connector, sender=model)
         signals.post_save.disconnect(self.post_save_connector, sender=model)
+
+    @cached_property
+    def buffer_size(self):
+        try:
+            return Bungiesearch.BUNGIE['SIGNALS']['BUFFER_SIZE']
+        except KeyError:
+            return 100


### PR DESCRIPTION
this is what I meant by using a timer to make sure that the buffer is always flushed every X interval
a timer object is created for each sender type that's queuing things

for this PR to be production quality, I need to:
- make the flush interval a configurable interval, right now its hard coded as 5s
- write unit test for this behavior somehow
- double check that there's no race condition