### PR TITLE
Fix install_requires in setup.py. Add missing common fields to AbstractField.

### DIFF
--- a/bungiesearch/fields.py
+++ b/bungiesearch/fields.py
@@ -12,7 +12,7 @@ class AbstractField(object):
 
     Values are extracted using the `model_attr` or `eval_as` attribute.
     '''
-    common_fields = ['index_name', 'store', 'index', 'boost', 'null_value', 'copy_to']
+    common_fields = ['index_name', 'store', 'index', 'boost', 'null_value', 'copy_to', 'type', 'fields']
     @property
     def fields(self):
         try:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(join(dirname(__file__), 'README.rst')) as f:
 install_requires = [
     'django>=1.7',
     'elasticsearch-dsl>=0.0.4',
-    'elasticsearch>=1.0.0,<=2.1.0'
+    'elasticsearch>=1.0.0,<=2.1.0',
     'python-dateutil',
     'six',
 ]


### PR DESCRIPTION
Two (unrelated) commits:

1. wrong requirements in setup.py;  ← @ChristopherRabotin this needs to be fixed for the next release
2. support Elasticsearch [multi-fields](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/mapping-core-types.html#_multi_fields_3).