### PR TITLE
Support overriding index settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.egg
+*.venv
 
 /venv
 /build/

--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -37,8 +37,10 @@ class Bungiesearch(Search):
         cls.__loaded_indices__ = True
 
         # Loading indices.
-        for index_name, module_str in iteritems(cls.BUNGIE['INDICES']):
+        for index_name, index_settings in iteritems(cls.BUNGIE['INDICES']):
+            module_str = index_settings['models']
             index_module = import_module(module_str)
+
             for index_obj in itervalues(index_module.__dict__):
                 try:
                     if issubclass(index_obj, ModelIndex) and index_obj != ModelIndex:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-elasticsearch-dsl>=0.0.4
-elasticsearch>=1.0.0,<=2.1.0
+elasticsearch-dsl>=0.0.4,<2.0.0
+elasticsearch>=1.0.0,<2.0.0
 python-dateutil
 six
 

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ with open(join(dirname(__file__), 'README.rst')) as f:
 
 install_requires = [
     'django>=1.7',
-    'elasticsearch-dsl>=0.0.4',
-    'elasticsearch>=1.0.0,<=2.1.0',
+    'elasticsearch-dsl>=0.0.4,<2.0.0',
+    'elasticsearch>=1.0.0,<2.0.0',
     'python-dateutil',
     'six',
 ]

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -1,9 +1,13 @@
 from bungiesearch import Bungiesearch
 from django.conf import settings
+from django.core.management import call_command
 from django.test import TestCase
 
 
 class SettingsTestCase(TestCase):
+
+    def tearDown(self):
+        call_command('search_index', action='delete', confirmed='guilty-as-charged')
 
     def test_timeout_used(self):
         settings.BUNGIESEARCH['TIMEOUT'] = 29
@@ -11,3 +15,25 @@ class SettingsTestCase(TestCase):
 
         self.assertEqual(search.BUNGIE['TIMEOUT'], 29)
         self.assertEqual(search._using.transport.kwargs['timeout'], 29)
+
+    def test_index_settings(self):
+        search = Bungiesearch()
+        config = settings.BUNGIESEARCH['INDICES']['bungiesearch_demo']['settings']
+
+        call_command('search_index', action='delete', confirmed='guilty-as-charged')
+        config['number_of_shards'] = 1
+        config['number_of_replicas'] = 0
+        call_command('search_index', action='create')
+
+        index_settings = search._using.indices.get('bungiesearch_demo')['bungiesearch_demo']['settings']['index']
+        self.assertEqual(index_settings['number_of_shards'], '1')
+        self.assertEqual(index_settings['number_of_replicas'], '0')
+
+        call_command('search_index', action='delete', confirmed='guilty-as-charged')
+        config['number_of_shards'] = 2
+        config['number_of_replicas'] = 0
+        call_command('search_index', action='create')
+
+        index_settings = search._using.indices.get('bungiesearch_demo')['bungiesearch_demo']['settings']['index']
+        self.assertEqual(index_settings['number_of_shards'], '2')
+        self.assertEqual(index_settings['number_of_replicas'], '0')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -37,11 +37,24 @@ BUNGIESEARCH = {
         'bsearch': 'core.search_aliases'
     },
     'INDICES': {
-        'bungiesearch_demo': 'core.search_indices',
-        'bungiesearch_demo_bis': 'core.search_indices_bis'
+        'bungiesearch_demo': {
+            'models': 'core.search_indices',
+            'settings': {
+                'number_of_shards': 1,
+                'number_of_replicas': 0,
+            }
+        },
+        'bungiesearch_demo_bis': {
+            'models': 'core.search_indices_bis',
+            'settings': {
+                'number_of_shards': 1,
+                'number_of_replicas': 0
+            }
+        }
     },
     'SIGNALS': {
         'BUFFER_SIZE': 1,
         'SIGNAL_CLASS': 'core.bungie_signal.BungieTestSignalProcessor'
-    }
+    },
+    'TIMEOUT': 30
 }


### PR DESCRIPTION
First... thanks to @jjhuang for putting up the ES 2.0 pull request! https://github.com/ChristopherRabotin/bungiesearch/pull/149

We need to merge in https://github.com/ChristopherRabotin/bungiesearch/pull/149 first but replication and sharing is now a per index option so we need a way to override it for when an index is created. Previously is was a more "global" setting. This expands the settings for each index to pave the way for overriding and specifying settings per index.

**This breaks backwards compat and will require a major version change.** I'm thinking that if we merge this in, and merge in ES 2.0 we can do a full major version change but I want to get feedback on this first.

**TODO**
- [x] Write a test for this setting
- [x] Upgrade documentation to suggest over-riding index options created for testing to disable sharding and replication
- [ ] Produce a list of major breaking changes to include with the release to ensure users know to change the format of their BungieSearch settings
