### PR TITLE
Don't attempt to lookup search aliases if Bungiesearch isn't setup

### DIFF
--- a/bungiesearch/managers.py
+++ b/bungiesearch/managers.py
@@ -1,3 +1,4 @@
+from django.conf import settings as dj_settings
 from django.db.models import Manager
 
 from .logger import logger
@@ -48,7 +49,8 @@ class BungiesearchManager(Manager):
         This function will check whether the given model is allowed to use the proposed alias and will raise an attribute error if not.
         '''
         # Don't treat "private" attrs as possible aliases. This prevents an infinite recursion bug.
-        if alias[0] == '_':
+        # Similarly, if Bungiesearch is installed but not enabled, raise the expected error
+        if alias[0] == '_' or not dj_settings.BUNGIESEARCH:
             raise AttributeError("'{}' object has no attribute '{}'".format(type(self), alias))
 
         return self.search.hook_alias(alias, self.model)

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from six import iteritems
 
 import pytz
@@ -193,6 +193,15 @@ class CoreTestCase(TestCase):
         self.assertRaises(AttributeError, getattr, Article.objects, 'bsearch_no_such_alias')
         self.assertRaises(NotImplementedError, Article.objects.bsearch_invalidalias)
         self.assertRaises(ValueError, getattr, Article.objects.search.bsearch_title('title query').bsearch_titlefilter('title filter'), 'bsearch_noupdatedmdlonly')
+
+    @override_settings(BUNGIESEARCH={})
+    def test_search_alias_not_setup(self):
+        '''
+        Tests that Bungiesearch is not instantiated when not set up
+        This is its own test due to the override_settings decorator
+        '''
+        self.assertRaises(AttributeError, getattr, Article.objects, 'bsearch_no_such_alias')
+        self.assertRaises(AttributeError, getattr, Article.objects, 'bsearch_title_search')
 
     def test_search_aliases(self):
         '''


### PR DESCRIPTION
And associated test.

As per Issue #160 

I included a simple test, however I wasn't able to get the tests to run on my local machine, so I can't guarantee that it passes