### PR TITLE
Django 1.10 test update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       env: DJANGO_VERSION=">=1.8,<1.9"
     - python: "2.7"
       env: DJANGO_VERSION=">=1.9,<1.10"
+    - python: "2.7"
+      env: DJANGO_VERSION=">=1.10,<1.11"
     - python: "3.4"
       env: DJANGO_VERSION=">=1.8,<1.9"
     - python: "3.4"
@@ -17,8 +19,9 @@ matrix:
     - python: "3.5"
       env: DJANGO_VERSION=">=1.8,<1.9"
     - python: "3.5"
-      env: DJANGO_VERSION=">=1.9,<1.10" COVERAGE=true
-
+      env: DJANGO_VERSION=">=1.9,<1.10"
+    - python: "3.5"
+      env: DJANGO_VERSION=">=1.10,<1.11" COVERAGE=true
 install:
   - pip install Django$DJANGO_VERSION
   - pip install -r requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,6 @@ Features
    -  Django >= 1.8
    -  Python 2.7, 3.4, 3.5
 
-**WARNING**: Django >= 1.10 is not fully supported yet.
-
 Feature examples
 ----------------
 

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -300,8 +300,7 @@ class CoreTestCase(TestCase):
         db_item = NoUpdatedField.objects.get(pk=1)
         src_item = NoUpdatedField.objects.search.query('match', field_title='My title')[0]
         self.assertEqual(src_item.id, db_item.id, 'Searching for the object did not return the expected object id.')
-        self.assertTrue(src_item._meta.proxy, 'Was expecting a proxy model after fetching item.')
-        self.assertEqual(src_item._meta.proxy_for_model, NoUpdatedField, 'Proxy for model of search item is not "NoUpdatedField".')
+        self.assertEqual(src_item.get_deferred_fields(), {'field_description'}, 'Was expecting description in the set of deferred fields.')
 
     def test_concat_queries(self):
         items = Article.objects.bsearch_title_search('title')[::False] + NoUpdatedField.objects.search.query('match', field_title='My title')[::False]


### PR DESCRIPTION
This seems to give 100% passing tests for Django 1.10, as proof I re-enabled the tests in travis.yml.

The failure is due to changes to how QuerySet.defer and QuerySet.only() function. `get_deferred_fields` was added in Django 1.8.

If there are other reasons it's marked unsupported, we can re-visit.